### PR TITLE
point cargo metadata to proper places

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -6,9 +6,8 @@ categories = [ "filesystem" ]
 version = "0.6.2"
 authors = [ "Till Höppner <till@hoeppner.ws>" ]
 license = "BSD-3-Clause"
-homepage = "https://github.com/tilpner/includedir"
-repository = "https://github.com/tilpner/includedir"
-documentation = "https://docs.rs/includedir_codegen"
+repository = "https://github.com/tauri-apps/tauri-includedir"
+documentation = "https://docs.rs/tauri_includedir_codegen"
 readme = "../README.md"
 edition = "2018"
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,9 +6,8 @@ categories = ["filesystem"]
 version = "0.6.0"
 authors = ["Till Höppner <till@hoeppner.ws>"]
 license = "BSD-3-Clause"
-homepage = "https://github.com/tilpner/includedir"
-repository = "https://github.com/tilpner/includedir"
-documentation = "https://docs.rs/includedir"
+repository = "https://github.com/tauri-apps/tauri-includedir"
+documentation = "https://docs.rs/tauri_includedir"
 readme = "../README.md"
 edition = "2018"
 


### PR DESCRIPTION
This updates the `repository` and `documentation` metadata to point to this repository/crate instead of the one it was forked from.  It's become more confusing since they diverged at an earlier fork but are now both `0.6` with slightly different public apis.  Now it's easier to find the correct repository from the [crates.io page](https://crates.io/crates/tauri_includedir) and [docs.rs page](https://docs.rs/tauri_includedir).

I've also simply removed the `homepage` key.