### PR TITLE
fix(codegen) compression usage when the paths are absolute

### DIFF
--- a/.changes/codegen-absolute-path.md
+++ b/.changes/codegen-absolute-path.md
@@ -1,0 +1,5 @@
+---
+"codegen": patch
+---
+
+Fixes the asset compression when the include paths absolute.


### PR DESCRIPTION
When `joining` Paths, if the path is absolute, Rust replaces the original Path. In that case, the includedir behavior of compressing the target file and move to OUT_DIR mutates the original file since we end up using the file path instead of `${OUT_DIR}/${path}`. This PR solves that behavior by removing the root from the source path when joining, so this behavior related to absolute paths doesn't happen. 